### PR TITLE
generate the autocompletion list in compile time

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "version": "0.1.0",
   "devDependencies": {
     "shadow-cljs": "2.26.1"
+  },
+  "scripts": {
+    "cleanup": "rm -rf target .shadow-cljs out"
   }
 }

--- a/project.clj
+++ b/project.clj
@@ -14,4 +14,5 @@
 
   :repl-options {:init-ns vsf.core}
 
-  :profiles {:dev {:dependencies [[vvvvalvalval/scope-capture "0.3.3"]]}})
+  :profiles {:dev  {:dependencies [[vvvvalvalval/scope-capture "0.3.3"]]}
+             :cljs {:dependencies [[thheller/shadow-cljs "2.26.1"]]}})

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,5 +1,5 @@
-{:source-paths
- ["src" "test"]
+{:lein
+ {:profile "+cljs"}
 
  :dev-http
  {8021 "out/test"}

--- a/src/vsf/completions.cljs
+++ b/src/vsf/completions.cljs
@@ -1,0 +1,7 @@
+(ns vsf.completions
+  (:require-macros
+   [vsf.process :refer [compile-completions]]))
+
+
+(def streams-completions
+  (compile-completions))

--- a/src/vsf/process.clj
+++ b/src/vsf/process.clj
@@ -228,7 +228,7 @@
     (fn stream [event]
       (let [event-time  (:time event)
             valid-event (condition-fn event)]
-        (when event-time ;; filter events with no time
+        (when event-time                                    ;; filter events with no time
           (let [{ok :ok time :time}
                 (swap! last-changed-state
                        (fn [{ok :ok time :time :as state}]
@@ -1261,3 +1261,13 @@
    :warning             warning*
    :where               where*
    :with                with*})
+
+
+(defmacro compile-completions []
+  (->> action->fn
+       (mapv (fn [[fn-key]]
+               (let [fn-name (name fn-key)
+                     fn-var  (requiring-resolve (symbol "vsf.action" fn-name))]
+                 {:label fn-name
+                  :type  "function"
+                  :info  (-> fn-var meta :doc)})))))

--- a/test/vsf/completions_test.cljc
+++ b/test/vsf/completions_test.cljc
@@ -1,0 +1,10 @@
+(ns vsf.completions-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   #?(:cljs [vsf.completions :as completions])))
+
+
+(deftest completions-list-test
+  #?(:cljs (is (vector? completions/streams-completions)))
+  #?(:cljs (is (every? #(= #{:label :type :info} (-> % keys set))
+                       completions/streams-completions))))


### PR DESCRIPTION
added a new cljs namespace that will contain a simple collection of maps suitable for autocompletion in the codemirror component